### PR TITLE
Use systemd to launch node service instead of using 'nohup'

### DIFF
--- a/install_ava_node.sh
+++ b/install_ava_node.sh
@@ -39,8 +39,33 @@ cd go/src/github.com/ava-labs/gecko
 echo '### Building AVA node...'
 ./scripts/build.sh
 
+echo '### Creating AVA node service...'
+sudo USER=$USER bash -c 'cat <<EOF > /etc/systemd/system/avanode.service
+[Unit]
+Description=AVA Node service
+After=network.target
+
+[Service]
+User=$USER
+Group=$USER
+
+WorkingDirectory=$HOME/go/src/github.com/ava-labs/gecko
+ExecStart=$HOME/go/src/github.com/ava-labs/gecko/build/ava
+
+Restart=always
+PrivateTmp=true
+TimeoutStopSec=60s
+TimeoutStartSec=10s
+StartLimitInterval=120s
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target
+EOF'
+
 echo '### Launching AVA node...'
-nohup ./build/ava &
+sudo systemctl enable avanode
+sudo systemctl start avanode
 
 echo '### Cloning Script directory...'
 cd $HOME


### PR DESCRIPTION
This modification uses Ubuntu's systemd service manager to run the AVA node as a service. Systemd will then start the service automatically at startup, monitor the service, restart it automatically if it crashes, manage the logs.

User can monitor the state of the node, the uptime, and last logs using command:
`sudo systemctl status avanode`

__Note__: This modification *should* be compatible with all systemd-based Linux distributions although it has only been tested on Ubuntu 18.04. It will not work in docker containers and Ubuntu for Windows (WSL) since they don't use systemd as their init manager.

If we want this script to be compatible with more distributions and not use systemd, we could use [supervisord](http://supervisord.org/) instead. Feel free to let me know if this second solution is preferred and I'll prepare another PR accordingly.