### PR TITLE
Use supervisord to monitor AVA node service in case systemd is not available

### DIFF
--- a/install_ava_node.sh
+++ b/install_ava_node.sh
@@ -5,6 +5,14 @@
 # for https://www.avalabs.org/ Nodes
 #######################################
 
+echo '### Checking if systemd is supported...'
+if systemctl show-environment &> /dev/null ; then
+SYSTEMD_SUPPORTED=1
+echo 'systemd is available, using it'
+else
+echo 'systemd is not available on this machine, will use supervisord instead'
+fi
+
 echo '### Updating packages...'
 sudo apt-get update -y
 
@@ -19,7 +27,9 @@ go version
 echo '### Installing dependencies...'
 sudo apt-get install libssl-dev libuv1-dev cmake make curl g++ -y
 sudo apt install git -y
-
+if [ ! -n "$SYSTEMD_SUPPORTED" ]; then
+sudo apt install supervisor
+fi
 
 echo '### Installing nodejs...'
 sudo apt-get update -y
@@ -40,6 +50,7 @@ echo '### Building AVA node...'
 ./scripts/build.sh
 
 echo '### Creating AVA node service...'
+if [ -n "$SYSTEMD_SUPPORTED" ]; then
 sudo USER=$USER bash -c 'cat <<EOF > /etc/systemd/system/avanode.service
 [Unit]
 Description=AVA Node service
@@ -62,10 +73,38 @@ StartLimitBurst=5
 [Install]
 WantedBy=multi-user.target
 EOF'
+else
+sudo bash -c 'cat <<EOF > /etc/supervisor/conf.d/avanode.conf
+[program:avanode]
+directory=/home/$SUDO_USER/go/src/github.com/ava-labs/gecko
+command=/home/$SUDO_USER/go/src/github.com/ava-labs/gecko/build/ava
+user=$SUDO_USER
+environment=HOME="/home/$SUDO_USER",USER="$SUDO_USER"
+autostart=true
+autorestart=true
+startsecs=10
+startretries=20
+stdout_logfile=/var/log/avanode-stdout.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=1
+stderr_logfile=/var/log/avanode-stderr.log
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=1
+EOF'
+fi
 
 echo '### Launching AVA node...'
+if [ -n "$SYSTEMD_SUPPORTED" ]; then
 sudo systemctl enable avanode
 sudo systemctl start avanode
+echo 'Type the following command to monitor the AVA node service:'
+echo '    sudo systemctl status avanode'
+else
+sudo service supervisor start
+sudo supervisorctl start avanode
+echo 'Type the following command to monitor the AVA node service:'
+echo '    sudo supervisorctl status avanode'
+fi
 
 echo '### Cloning Script directory...'
 cd $HOME


### PR DESCRIPTION
This patch checks if `systemd` is available:
- if yes, use it as the process monitor just like before
- if no, install `supervisord` and configure it to monitor the node process

At the end, display the command the use should call to check the node status depending on the monitoring service used.

This patch has been tested working on Ubuntu WSL 20.04, and should work in docker containers as well (although untested).